### PR TITLE
fix failing verify checksums for minio_archive

### DIFF
--- a/cloud_archive.bzl
+++ b/cloud_archive.bzl
@@ -179,7 +179,7 @@ def cloud_download(
         file_version = "",
         downloaded_file_path = ""):
     """ Securely downloads a file from Minio. """
-    downloaded_file_path = downloaded_file_path or file_path
+    downloaded_file_path = downloaded_file_path or repo_ctx.path(file_path).basename
 
     # Download tooling is pretty similar, but commands are different. Note that
     # Minio does not support bucket per se. The path is expected to contain what
@@ -194,11 +194,11 @@ def cloud_download(
         cmd = [tool_path, "cp", src_url, downloaded_file_path]
     elif provider == "s3":
         tool_path = repo_ctx.which("aws")
+        src_url = file_path
         extra_flags = ["--profile", profile] if profile else []
         bucket_arg = ["--bucket", bucket]
         file_arg = ["--key", file_path]
         file_version_arg = ["--version-id", file_version] if file_version else []
-        src_url = repo_ctx.path(file_path).basename
         cmd = [tool_path] + extra_flags + ["s3api", "get-object"] + bucket_arg + file_arg + file_version_arg + [downloaded_file_path]
     elif provider == "backblaze":
         # NOTE: currently untested, as I don't have a B2 account.


### PR DESCRIPTION
Apologies. I seemed to have introduced a regression in https://github.com/1e100/cloud_archive/commit/cc1c12a31a32e508ad57ddd2a3cb2e8bcb04c418,

```
ERROR: /tmp/tmpss4hhm8j/external/cloud_archive/cloud_archive.bzl:28:13: An error occurred during the fetch of repository 'test_archive_p1_patch':
   Traceback (most recent call last):
	File "/tmp/tmpss4hhm8j/external/cloud_archive/cloud_archive.bzl", line 238, column 27, in _cloud_archive_impl
		cloud_archive_download(
	File "/tmp/tmpss4hhm8j/external/cloud_archive/cloud_archive.bzl", line 134, column 19, in cloud_archive_download
		cloud_download(repo_ctx, file_path, expected_sha256, provider, bucket, profile, file_version)
	File "/tmp/tmpss4hhm8j/external/cloud_archive/cloud_archive.bzl", line 221, column 22, in cloud_download
		validate_checksum(repo_ctx, file_path, downloaded_file_path, expected_sha256)
	File "/tmp/tmpss4hhm8j/external/cloud_archive/cloud_archive.bzl", line 28, column 13, in validate_checksum
		fail("Failed to verify checksum: {}".format(sha256_result.stderr))
Error in fail: Failed to verify checksum: sha256sum: local/bucket/data.tar.gz: No such file or directory
ERROR: Failed to verify checksum: sha256sum: local/bucket/data.tar.gz: No such file or directory
```

Confirmed the integration tests introduced in https://github.com/1e100/cloud_archive/pull/12 pass with this applied