### PR TITLE
Replace bash execution with repo_ctx.delete for BUILD file removal

### DIFF
--- a/cloud_archive.bzl
+++ b/cloud_archive.bzl
@@ -61,12 +61,13 @@ def extract_archive(repo_ctx, local_path, strip_prefix, add_prefix, build_file, 
 
     # Provide external BUILD file if requested; `build_file_contents` takes
     # priority.
-    bash_path = repo_ctx.os.environ.get("BAZEL_SH", "bash")
     if build_file_contents:
-        repo_ctx.execute([bash_path, "-c", "rm -f BUILD BUILD.bazel"])
+        repo_ctx.delete("BUILD")
+        repo_ctx.delete("BUILD.bazel")
         repo_ctx.file("BUILD.bazel", build_file_contents, executable = False)
     elif build_file:
-        repo_ctx.execute([bash_path, "-c", "rm -f BUILD BUILD.bazel"])
+        repo_ctx.delete("BUILD")
+        repo_ctx.delete("BUILD.bazel")
         repo_ctx.symlink(build_file, "BUILD.bazel")
 
 _TYPE_DOC = """The archive type of the downloaded file.


### PR DESCRIPTION
## Summary
Refactored the BUILD file cleanup logic in `cloud_archive.bzl` to use Bazel's native `repo_ctx.delete()` API instead of executing bash commands.

## Key Changes
- Removed dependency on `BAZEL_SH` environment variable and bash execution for deleting BUILD files
- Replaced `repo_ctx.execute([bash_path, "-c", "rm -f BUILD BUILD.bazel"])` with two separate `repo_ctx.delete()` calls for each file
- Applied this change in both the `build_file_contents` and `build_file` conditional branches

## Benefits
- Improved cross-platform compatibility by eliminating bash dependency
- Cleaner, more idiomatic Bazel code using native repository context APIs
- Reduced complexity and potential shell escaping issues