### PR TITLE
Extract shared test helper function into reusable library

### DIFF
--- a/BUILD.main
+++ b/BUILD.main
@@ -1,3 +1,9 @@
+sh_library(
+    name = "test_helpers",
+    srcs = ["test_helpers.sh"],
+    visibility = ["//visibility:public"],
+)
+
 sh_test(
     name = "local_archive_test",
     srcs = ["local_archive_test.sh"],
@@ -11,5 +17,8 @@ sh_test(
         "@test_local_archive_add_prefix//:files",
         "@test_local_archive_type//:files",
     ],
-    deps = ["@bazel_tools//tools/bash/runfiles"],
+    deps = [
+        ":test_helpers",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
 )

--- a/e2e/BUILD.bazel
+++ b/e2e/BUILD.bazel
@@ -7,5 +7,8 @@ sh_test(
         "@test_minio_archive_zstd//:files",
         "@test_minio_archive_patch//:files",
     ],
-    deps = ["@bazel_tools//tools/bash/runfiles"],
+    deps = [
+        "//:test_helpers",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
 )

--- a/e2e/minio_e2e_test.sh
+++ b/e2e/minio_e2e_test.sh
@@ -16,26 +16,8 @@ set -e
 PASS=0
 FAIL=0
 
-assert_file_contains() {
-    local rloc="$1"
-    local expected="$2"
-    local label="$3"
-    local file
-    file="$(rlocation "$rloc")"
-    if [ ! -f "$file" ]; then
-        echo "FAIL [$label]: file not found: $file (rlocation of $rloc)"
-        FAIL=$((FAIL + 1))
-        return
-    fi
-    actual="$(cat "$file")"
-    if [ "$actual" = "$expected" ]; then
-        echo "PASS [$label]"
-        PASS=$((PASS + 1))
-    else
-        echo "FAIL [$label]: expected '$expected', got '$actual'"
-        FAIL=$((FAIL + 1))
-    fi
-}
+# shellcheck source=../test_helpers.sh
+source "$(rlocation cloud_archive/test_helpers.sh)"
 
 # Test 1: minio_file - basic file download + checksum
 assert_file_contains \

--- a/local_archive_test.sh
+++ b/local_archive_test.sh
@@ -17,26 +17,8 @@ set -e
 PASS=0
 FAIL=0
 
-assert_file_contains() {
-    local rloc="$1"
-    local expected="$2"
-    local label="$3"
-    local file
-    file="$(rlocation "$rloc")"
-    if [ ! -f "$file" ]; then
-        echo "FAIL [$label]: file not found: $file (rlocation of $rloc)"
-        FAIL=$((FAIL + 1))
-        return
-    fi
-    actual="$(cat "$file")"
-    if [ "$actual" = "$expected" ]; then
-        echo "PASS [$label]"
-        PASS=$((PASS + 1))
-    else
-        echo "FAIL [$label]: expected '$expected', got '$actual'"
-        FAIL=$((FAIL + 1))
-    fi
-}
+# shellcheck source=test_helpers.sh
+source "$(rlocation cloud_archive/test_helpers.sh)"
 
 # Test 1: local_file - basic file download + checksum
 assert_file_contains \

--- a/test_helpers.sh
+++ b/test_helpers.sh
@@ -1,0 +1,23 @@
+# Shared test helpers for cloud_archive sh_tests.
+# Source this file after Bazel runfiles initialization so that rlocation is available.
+
+assert_file_contains() {
+    local rloc="$1"
+    local expected="$2"
+    local label="$3"
+    local file
+    file="$(rlocation "$rloc")"
+    if [ ! -f "$file" ]; then
+        echo "FAIL [$label]: file not found: $file (rlocation of $rloc)"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+    actual="$(cat "$file")"
+    if [ "$actual" = "$expected" ]; then
+        echo "PASS [$label]"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL [$label]: expected '$expected', got '$actual'"
+        FAIL=$((FAIL + 1))
+    fi
+}


### PR DESCRIPTION
## Summary
Refactored duplicate test helper code by extracting the `assert_file_contains()` function into a shared library that can be reused across multiple shell test files.

## Key Changes
- Created new `test_helpers.sh` library containing the `assert_file_contains()` helper function
- Removed duplicate `assert_file_contains()` function definitions from `local_archive_test.sh` and `e2e/minio_e2e_test.sh`
- Updated both test files to source the shared helper library
- Added `sh_library` target for `test_helpers.sh` in the main BUILD file
- Updated BUILD dependencies in both `BUILD.main` and `e2e/BUILD.bazel` to reference the new shared library

## Implementation Details
- The shared library includes a shellcheck directive to document the source relationship
- Both test files now source the helper using `rlocation` to support Bazel's runfiles mechanism
- The library is marked with `visibility = ["//visibility:public"]` to allow cross-package dependencies