### PR TITLE
Update Backblaze B2 download command to use current CLI syntax

### DIFF
--- a/cloud_archive.bzl
+++ b/cloud_archive.bzl
@@ -258,7 +258,7 @@ def cloud_download(
         elif provider == "backblaze":
             # NOTE: currently untested, as I don't have a B2 account.
             src_url = "b2://{}/{}".format(bucket, file_path)
-            cmd = [tool_path, "download-file-by-name", "--noProgress", bucket, file_path, downloaded_file_path]
+            cmd = [tool_path, "file", "download", "--no-progress", src_url, downloaded_file_path]
 
     # Download.
     repo_ctx.report_progress("Downloading {}.".format(src_url))


### PR DESCRIPTION
## Summary
Updated the Backblaze B2 CLI command invocation to use the current command syntax and flags.

## Key Changes
- Changed B2 download command from `download-file-by-name` to `file download` subcommand structure
- Updated flag from `--noProgress` to `--no-progress` (kebab-case)
- Modified command arguments to use the constructed `src_url` instead of separate bucket and file_path parameters

## Implementation Details
The B2 CLI has evolved its command structure. The new syntax uses a nested command pattern (`file download`) and accepts the full B2 URL (`b2://bucket/path`) as a parameter rather than separate bucket and file path arguments. This change aligns the implementation with the current B2 CLI API while maintaining the same functional behavior.