### PR TITLE
Add unified test runner script for unit and E2E tests

### DIFF
--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Runs all tests in the cloud_archive repository:
+#   1. Unit tests  – local_archive_test (no external services required)
+#   2. End-to-end tests – minio_e2e_test (spins up a local MinIO server)
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+cd "$REPO_ROOT"
+
+UNIT_PASS=false
+E2E_PASS=false
+
+# ---------------------------------------------------------------------------
+# Unit tests
+# ---------------------------------------------------------------------------
+echo "========================================"
+echo " Running unit tests"
+echo "========================================"
+if bazel test //:local_archive_test --test_output=all; then
+    UNIT_PASS=true
+else
+    echo "ERROR: Unit tests FAILED." >&2
+fi
+
+# ---------------------------------------------------------------------------
+# End-to-end tests
+# ---------------------------------------------------------------------------
+echo ""
+echo "========================================"
+echo " Running end-to-end tests"
+echo "========================================"
+if "$REPO_ROOT/e2e/run_tests.sh"; then
+    E2E_PASS=true
+else
+    echo "ERROR: End-to-end tests FAILED." >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "========================================"
+echo " Summary"
+echo "========================================"
+echo "  Unit tests : $( $UNIT_PASS && echo PASS || echo FAIL )"
+echo "  E2E tests  : $( $E2E_PASS  && echo PASS || echo FAIL )"
+echo "========================================"
+
+$UNIT_PASS && $E2E_PASS


### PR DESCRIPTION
## Summary
This PR introduces a new `run_all_tests.sh` script that provides a unified entry point for running all tests in the cloud_archive repository, including both unit tests and end-to-end tests with a consolidated summary report.

## Key Changes
- Added `run_all_tests.sh` script that orchestrates the complete test suite
- Runs unit tests via Bazel (`//:local_archive_test`)
- Runs end-to-end tests via the existing `e2e/run_tests.sh` script
- Provides clear console output with section headers for each test phase
- Generates a summary report showing pass/fail status for both test suites
- Uses strict error handling (`set -euo pipefail`) to ensure proper exit codes
- Returns success only if all test suites pass

## Implementation Details
- The script tracks test results in boolean flags (`UNIT_PASS` and `E2E_PASS`) to allow all tests to run even if one suite fails
- Error messages are written to stderr for failed test suites
- The final exit code reflects the overall test result (0 only if all tests pass)
- Script is repository-root agnostic by determining the repo root from the script's location