### PR TITLE
Refactor cloud provider rules to fix Starlark build-context scope

### DIFF
--- a/cloud_archive.bzl
+++ b/cloud_archive.bzl
@@ -431,23 +431,21 @@ _COMMON_CLOUD_ARCHIVE_ATTRS = {
     "_tools_config": attr.label(default = "@cloud_archive_tools//:config.json", allow_single_file = True),
 }
 
-def _make_cloud_file_rule(provider, file_path_doc, extra_attrs = None):
-    """Create a repository_rule for downloading a single file from a cloud provider."""
+def _cloud_file_attrs(file_path_doc, extra_attrs, provider):
+    """Build the attrs dict for a cloud file repository rule."""
     attrs = {"file_path": attr.string(mandatory = True, doc = file_path_doc)}
     attrs.update(_COMMON_CLOUD_FILE_ATTRS)
-    if extra_attrs:
-        attrs.update(extra_attrs)
+    attrs.update(extra_attrs)
     attrs["_provider"] = attr.string(default = provider)
-    return repository_rule(implementation = _cloud_file_impl, attrs = attrs)
+    return attrs
 
-def _make_cloud_archive_rule(provider, file_path_doc, extra_attrs = None):
-    """Create a repository_rule for downloading and extracting an archive from a cloud provider."""
+def _cloud_archive_attrs(file_path_doc, extra_attrs, provider):
+    """Build the attrs dict for a cloud archive repository rule."""
     attrs = {"file_path": attr.string(mandatory = True, doc = file_path_doc)}
     attrs.update(_COMMON_CLOUD_ARCHIVE_ATTRS)
-    if extra_attrs:
-        attrs.update(extra_attrs)
+    attrs.update(extra_attrs)
     attrs["_provider"] = attr.string(default = provider)
-    return repository_rule(implementation = _cloud_archive_impl, attrs = attrs)
+    return attrs
 
 # -- Provider-specific extra attrs. ------------------------------------------
 
@@ -469,18 +467,44 @@ _B2_EXTRA = {
 }
 
 # -- Cloud provider rules. ---------------------------------------------------
+# repository_rule() is called directly at module level (not inside a helper
+# function) to avoid Starlark build-context scope errors.
 
-minio_file = _make_cloud_file_rule("minio", _MINIO_PATH_DOC)
-minio_archive = _make_cloud_archive_rule("minio", _MINIO_PATH_DOC)
+minio_file = repository_rule(
+    implementation = _cloud_file_impl,
+    attrs = _cloud_file_attrs(_MINIO_PATH_DOC, {}, "minio"),
+)
+minio_archive = repository_rule(
+    implementation = _cloud_archive_impl,
+    attrs = _cloud_archive_attrs(_MINIO_PATH_DOC, {}, "minio"),
+)
 
-s3_file = _make_cloud_file_rule("s3", _BUCKET_PATH_DOC, _S3_EXTRA)
-s3_archive = _make_cloud_archive_rule("s3", _BUCKET_PATH_DOC, _S3_EXTRA)
+s3_file = repository_rule(
+    implementation = _cloud_file_impl,
+    attrs = _cloud_file_attrs(_BUCKET_PATH_DOC, _S3_EXTRA, "s3"),
+)
+s3_archive = repository_rule(
+    implementation = _cloud_archive_impl,
+    attrs = _cloud_archive_attrs(_BUCKET_PATH_DOC, _S3_EXTRA, "s3"),
+)
 
-gs_file = _make_cloud_file_rule("google", _BUCKET_PATH_DOC, _GS_EXTRA)
-gs_archive = _make_cloud_archive_rule("google", _BUCKET_PATH_DOC, _GS_EXTRA)
+gs_file = repository_rule(
+    implementation = _cloud_file_impl,
+    attrs = _cloud_file_attrs(_BUCKET_PATH_DOC, _GS_EXTRA, "google"),
+)
+gs_archive = repository_rule(
+    implementation = _cloud_archive_impl,
+    attrs = _cloud_archive_attrs(_BUCKET_PATH_DOC, _GS_EXTRA, "google"),
+)
 
-b2_file = _make_cloud_file_rule("backblaze", _BUCKET_PATH_DOC, _B2_EXTRA)
-b2_archive = _make_cloud_archive_rule("backblaze", _BUCKET_PATH_DOC, _B2_EXTRA)
+b2_file = repository_rule(
+    implementation = _cloud_file_impl,
+    attrs = _cloud_file_attrs(_BUCKET_PATH_DOC, _B2_EXTRA, "backblaze"),
+)
+b2_archive = repository_rule(
+    implementation = _cloud_archive_impl,
+    attrs = _cloud_archive_attrs(_BUCKET_PATH_DOC, _B2_EXTRA, "backblaze"),
+)
 
 # The local_file and local_archive rules exist solely for testing. They
 # exercise the full pipeline (checksum, extraction, strip_prefix, patching,

--- a/e2e/BUILD.bazel
+++ b/e2e/BUILD.bazel
@@ -8,7 +8,7 @@ sh_test(
         "@test_minio_archive_patch//:files",
     ],
     deps = [
-        "//:test_helpers",
+        "@cloud_archive//:test_helpers",
         "@bazel_tools//tools/bash/runfiles",
     ],
 )


### PR DESCRIPTION
## Summary
Refactored the cloud provider rule creation to avoid Starlark build-context scope errors by calling `repository_rule()` directly at module level instead of inside helper functions.

## Key Changes
- Split `_make_cloud_file_rule()` and `_make_cloud_archive_rule()` into separate attribute-building functions (`_cloud_file_attrs()` and `_cloud_archive_attrs()`) that return attribute dictionaries instead of repository rules
- Moved `repository_rule()` calls to module level for all cloud provider rules (minio, s3, gs, b2), eliminating the indirection through helper functions
- Simplified attribute merging by removing conditional checks for `extra_attrs` (now always calls `update()`)
- Updated test dependency reference from relative path to absolute label (`//:test_helpers` → `@cloud_archive//:test_helpers`)

## Implementation Details
The refactoring addresses a Starlark limitation where `repository_rule()` cannot be called from within a function in certain build contexts. By moving the `repository_rule()` calls to the module level and having the helper functions only build and return the attributes dictionary, the code maintains the same functionality while respecting Starlark's scoping rules. This pattern is now documented with a comment explaining why `repository_rule()` is called directly at module level.
